### PR TITLE
Implement EIC-based buttons controller + example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ heapless = "~0.5"
 ili9341 = "~0.4"
 
 [dependencies.atsamd-hal]
-path = "../atsamd/hal"
+git = "https://github.com/atsamd-rs/atsamd"
+rev = "b075ee1f95bc0ffe78a374024b2471abac70b2cb"
 
 [dependencies.lis3dh]
 git = "https://github.com/BenBergman/lis3dh-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,7 @@ heapless = "~0.5"
 ili9341 = "~0.4"
 
 [dependencies.atsamd-hal]
-git = "https://github.com/atsamd-rs/atsamd"
-rev = "54cb571de48beee6d3a3ba61d87e27185536b879"
+path = "../atsamd/hal"
 
 [dependencies.lis3dh]
 git = "https://github.com/BenBergman/lis3dh-rs"
@@ -71,3 +70,7 @@ name = "blinky"
 
 [[example]]
 name = "orientation"
+
+[[example]]
+name = "buttons"
+# required-features = ["unflappable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,3 @@ name = "orientation"
 
 [[example]]
 name = "buttons"
-# required-features = ["unflappable"]

--- a/examples/buttons.rs
+++ b/examples/buttons.rs
@@ -1,0 +1,189 @@
+#![no_std]
+#![no_main]
+
+use embedded_graphics as eg;
+use panic_halt as _;
+use wio_terminal as wio;
+
+use eg::pixelcolor::Rgb565;
+use eg::prelude::*;
+use eg::primitives::{circle::Circle, rectangle::Rectangle, triangle::Triangle};
+use eg::style::{PrimitiveStyle, PrimitiveStyleBuilder};
+
+use wio::buttons::{Button, ButtonController, ButtonEvent};
+use wio::hal::clock::GenericClockController;
+use wio::hal::delay::Delay;
+use wio::pac::{interrupt, CorePeripherals, Peripherals};
+use wio::prelude::*;
+use wio::{button_interrupt, entry, Pins, Sets};
+
+use cortex_m::interrupt::free as disable_interrupts;
+
+use heapless::consts::U8;
+use heapless::spsc::Queue;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let pins = Pins::new(peripherals.PORT);
+    let mut sets: Sets = pins.split();
+
+    // Initialize the ILI9341-based LCD display. Create a black backdrop the size of
+    // the screen, load an image of Ferris from a RAW file, and draw it to the
+    // screen.
+    // By default, the display is in the LandscapeFlipped orientation.
+    let (mut display, _backlight) = sets
+        .display
+        .init(
+            &mut clocks,
+            peripherals.SERCOM7,
+            &mut peripherals.MCLK,
+            &mut sets.port,
+            &mut delay,
+        )
+        .unwrap();
+
+    let style = PrimitiveStyleBuilder::new()
+        .fill_color(Rgb565::BLACK)
+        .build();
+    let backdrop = Rectangle::new(Point::new(0, 0), Point::new(320, 320)).into_styled(style);
+    backdrop.draw(&mut display).unwrap();
+
+    let button_ctrlr = sets.buttons.init(
+        peripherals.EIC,
+        &mut clocks,
+        &mut peripherals.MCLK,
+        &mut sets.port,
+    );
+    let nvic = &mut core.NVIC;
+    disable_interrupts(|_| unsafe {
+        button_ctrlr.enable(nvic);
+        BUTTON_CTRLR = Some(button_ctrlr);
+    });
+
+    let mut consumer = unsafe { Q.split().1 };
+    loop {
+        if let Some(press) = consumer.dequeue() {
+            let color = match press.down {
+                true => Rgb565::RED,
+                false => Rgb565::BLACK,
+            };
+
+            draw_button_marker(
+                &mut display,
+                press.button,
+                PrimitiveStyleBuilder::new().fill_color(color).build(),
+            );
+        }
+    }
+}
+
+fn draw_button_marker<D: DrawTarget<Rgb565>>(
+    display: &mut D,
+    button: Button,
+    style: PrimitiveStyle<Rgb565>,
+) {
+    match button {
+        Button::TopLeft => {
+            Rectangle::new(Point::new(5, 5), Point::new(5, 35))
+                .into_styled(style)
+                .draw(display)
+                .ok();
+            Triangle::new(Point::new(0, 5), Point::new(5, 0), Point::new(10, 5))
+                .into_styled(style)
+                .draw(display)
+                .ok();
+        }
+        Button::TopMiddle => {
+            Rectangle::new(Point::new(80, 5), Point::new(80, 35))
+                .into_styled(style)
+                .draw(display)
+                .ok();
+            Triangle::new(Point::new(75, 5), Point::new(80, 0), Point::new(85, 5))
+                .into_styled(style)
+                .draw(display)
+                .ok();
+        }
+        Button::Left => {
+            Rectangle::new(Point::new(90, 120), Point::new(120, 120))
+                .into_styled(style)
+                .draw(display)
+                .ok();
+            Triangle::new(
+                Point::new(90, 115),
+                Point::new(85, 120),
+                Point::new(90, 125),
+            )
+            .into_styled(style)
+            .draw(display)
+            .ok();
+        }
+        Button::Right => {
+            Rectangle::new(Point::new(190, 120), Point::new(220, 120))
+                .into_styled(style)
+                .draw(display)
+                .ok();
+            Triangle::new(
+                Point::new(220, 115),
+                Point::new(225, 120),
+                Point::new(220, 125),
+            )
+            .into_styled(style)
+            .draw(display)
+            .ok();
+        }
+        Button::Down => {
+            Rectangle::new(Point::new(160, 150), Point::new(160, 180))
+                .into_styled(style)
+                .draw(display)
+                .ok();
+            Triangle::new(
+                Point::new(155, 180),
+                Point::new(160, 185),
+                Point::new(165, 180),
+            )
+            .into_styled(style)
+            .draw(display)
+            .ok();
+        }
+        Button::Up => {
+            Rectangle::new(Point::new(160, 60), Point::new(160, 90))
+                .into_styled(style)
+                .draw(display)
+                .ok();
+            Triangle::new(
+                Point::new(155, 60),
+                Point::new(160, 55),
+                Point::new(165, 60),
+            )
+            .into_styled(style)
+            .draw(display)
+            .ok();
+        }
+        Button::Click => {
+            Circle::new(Point::new(160, 120), 15)
+                .into_styled(style)
+                .draw(display)
+                .ok();
+        }
+    }
+}
+
+static mut BUTTON_CTRLR: Option<ButtonController> = None;
+static mut Q: Queue<ButtonEvent, U8> = Queue(heapless::i::Queue::new());
+
+button_interrupt!(BUTTON_CTRLR, unsafe fn on_button_event(_cs CriticalSection, event ButtonEvent) {
+    let mut q = Q.split().0;
+    q.enqueue(event).ok();
+});

--- a/examples/buttons.rs
+++ b/examples/buttons.rs
@@ -17,7 +17,7 @@ use wio::pac::{interrupt, CorePeripherals, Peripherals};
 use wio::prelude::*;
 use wio::{button_interrupt, entry, Pins, Sets};
 
-use cortex_m::interrupt::free as disable_interrupts;
+use cortex_m::interrupt::{free as disable_interrupts, CriticalSection};
 
 use heapless::consts::U8;
 use heapless::spsc::Queue;
@@ -183,7 +183,10 @@ fn draw_button_marker<D: DrawTarget<Rgb565>>(
 static mut BUTTON_CTRLR: Option<ButtonController> = None;
 static mut Q: Queue<ButtonEvent, U8> = Queue(heapless::i::Queue::new());
 
-button_interrupt!(BUTTON_CTRLR, unsafe fn on_button_event(_cs CriticalSection, event ButtonEvent) {
-    let mut q = Q.split().0;
-    q.enqueue(event).ok();
-});
+button_interrupt!(
+    BUTTON_CTRLR,
+    unsafe fn on_button_event(_cs: &CriticalSection, event: ButtonEvent) {
+        let mut q = Q.split().0;
+        q.enqueue(event).ok();
+    }
+);

--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -1,0 +1,198 @@
+use atsamd_hal::clock::GenericClockController;
+use atsamd_hal::common::eic;
+use atsamd_hal::common::eic::pin::*;
+use atsamd_hal::gpio::*;
+use atsamd_hal::target_device::{interrupt, EIC, MCLK};
+
+use cortex_m::peripheral::NVIC;
+
+/// pushbuttons and joystick
+pub struct ButtonPins {
+    /// button1 pin
+    pub button1: Pc26<Input<Floating>>,
+    /// button2 pin
+    pub button2: Pc27<Input<Floating>>,
+    /// button3 pin
+    pub button3: Pc28<Input<Floating>>,
+
+    /// Joystick X
+    pub switch_x: Pd8<Input<Floating>>,
+    /// Joystick Y
+    pub switch_y: Pd9<Input<Floating>>,
+    /// Joystick Z
+    pub switch_z: Pd10<Input<Floating>>,
+    /// Joystick U
+    pub switch_u: Pd20<Input<Floating>>,
+    /// Joystick B
+    pub switch_b: Pd12<Input<Floating>>,
+}
+
+impl ButtonPins {
+    pub fn init(
+        self,
+        eic: EIC,
+        clocks: &mut GenericClockController,
+        mclk: &mut MCLK,
+        port: &mut Port,
+    ) -> ButtonController {
+        let clk = clocks.gclk1();
+        let mut eic = eic::init_with_ulp32k(mclk, clocks.eic(&clk).unwrap(), eic);
+        eic.button_debounce_pins(&[
+            self.button1.id(),
+            self.button2.id(),
+            self.button3.id(),
+            self.switch_x.id(),
+            self.switch_y.id(),
+            self.switch_z.id(),
+            self.switch_u.id(),
+            self.switch_b.id(),
+        ]);
+
+        // let mut b1 = self.button1.into_ei(port);
+        let mut b2 = self.button2.into_ei(port);
+        let mut b3 = self.button3.into_ei(port);
+        let mut x = self.switch_x.into_ei(port);
+        let mut y = self.switch_y.into_ei(port);
+        let mut z = self.switch_z.into_ei(port);
+        let mut u = self.switch_u.into_ei(port);
+        let mut b = self.switch_b.into_ei(port);
+
+        // b1.sense(&mut eic, Sense::BOTH);
+        b2.sense(&mut eic, Sense::BOTH);
+        b3.sense(&mut eic, Sense::BOTH);
+        x.sense(&mut eic, Sense::BOTH);
+        y.sense(&mut eic, Sense::BOTH);
+        z.sense(&mut eic, Sense::BOTH);
+        u.sense(&mut eic, Sense::BOTH);
+        b.sense(&mut eic, Sense::BOTH);
+
+        // b1.enable_interrupt(&mut eic);
+        b2.enable_interrupt(&mut eic);
+        b3.enable_interrupt(&mut eic);
+        x.enable_interrupt(&mut eic);
+        y.enable_interrupt(&mut eic);
+        z.enable_interrupt(&mut eic);
+        u.enable_interrupt(&mut eic);
+        b.enable_interrupt(&mut eic);
+
+        ButtonController {
+            _eic: eic.finalize(),
+            // b1,
+            b2,
+            b3,
+            x,
+            y,
+            z,
+            u,
+            b,
+        }
+    }
+}
+
+pub enum Button {
+    TopLeft,
+    TopMiddle,
+    // TopRight,
+    Down,
+    Up,
+    Left,
+    Right,
+    Click,
+}
+
+pub struct ButtonEvent {
+    pub button: Button,
+    pub down: bool,
+}
+
+pub struct ButtonController {
+    _eic: eic::EIC,
+    // b1: ExtInt10<Pc26<PfA>>,
+    b2: ExtInt11<Pc27<PfA>>,
+    b3: ExtInt12<Pc28<PfA>>,
+
+    x: ExtInt3<Pd8<PfA>>,
+    y: ExtInt4<Pd9<PfA>>,
+    z: ExtInt5<Pd10<PfA>>,
+    u: ExtInt10<Pd20<PfA>>,
+    b: ExtInt7<Pd12<PfA>>,
+}
+
+macro_rules! isr {
+    ($Handler:ident, $($Event:expr, $Button:ident),+) => {
+        pub fn $Handler(&mut self) -> Option<ButtonEvent> {
+            $(
+                {
+                    let b = &mut self.$Button;
+                    if b.is_interrupt() {
+                        b.clear_interrupt();
+                        return Some(ButtonEvent {
+                            button: $Event,
+                            down: !b.state(),
+                        })
+                    }
+                }
+            )+
+
+            None
+        }
+    };
+}
+
+impl ButtonController {
+    pub fn enable(&self, nvic: &mut NVIC) {
+        unsafe {
+            nvic.set_priority(interrupt::EIC_EXTINT_10, 1);
+            NVIC::unmask(interrupt::EIC_EXTINT_10);
+            nvic.set_priority(interrupt::EIC_EXTINT_11, 1);
+            NVIC::unmask(interrupt::EIC_EXTINT_11);
+            nvic.set_priority(interrupt::EIC_EXTINT_12, 1);
+            NVIC::unmask(interrupt::EIC_EXTINT_12);
+            nvic.set_priority(interrupt::EIC_EXTINT_3, 1);
+            NVIC::unmask(interrupt::EIC_EXTINT_3);
+            nvic.set_priority(interrupt::EIC_EXTINT_4, 1);
+            NVIC::unmask(interrupt::EIC_EXTINT_4);
+            nvic.set_priority(interrupt::EIC_EXTINT_5, 1);
+            NVIC::unmask(interrupt::EIC_EXTINT_5);
+            nvic.set_priority(interrupt::EIC_EXTINT_7, 1);
+            NVIC::unmask(interrupt::EIC_EXTINT_7);
+        }
+    }
+
+    isr!(interrupt_extint3, Button::Down, x);
+    isr!(interrupt_extint4, Button::Right, y);
+    isr!(interrupt_extint5, Button::Click, z);
+    isr!(interrupt_extint7, Button::Left, b);
+    isr!(interrupt_extint10, Button::Up, u);
+    // isr!(interrupt_extint10, Button::TopRight, b1);
+    isr!(interrupt_extint11, Button::TopMiddle, b2);
+    isr!(interrupt_extint12, Button::TopLeft, b3);
+}
+
+#[macro_export]
+macro_rules! button_interrupt {
+    ($controller:ident, unsafe fn $func_name:ident ($cs:ident $cstype:ty, $event:ident ButtonEvent ) $code:block) => {
+        macro_rules! handler {
+            ($Interrupt:ident, $Handler:ident) => {
+                #[interrupt]
+                fn $Interrupt() {
+                    disable_interrupts(|$cs| unsafe {
+                        $controller.as_mut().map(|ctrlr| {
+                            if let Some($event) = ctrlr.$Handler() {
+                                $code
+                            }
+                        });
+                    });
+                }
+            };
+        }
+
+        handler!(EIC_EXTINT_3, interrupt_extint3);
+        handler!(EIC_EXTINT_4, interrupt_extint4);
+        handler!(EIC_EXTINT_5, interrupt_extint5);
+        handler!(EIC_EXTINT_7, interrupt_extint7);
+        handler!(EIC_EXTINT_10, interrupt_extint10);
+        handler!(EIC_EXTINT_11, interrupt_extint11);
+        handler!(EIC_EXTINT_12, interrupt_extint12);
+    };
+}

--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -171,14 +171,14 @@ impl ButtonController {
 
 #[macro_export]
 macro_rules! button_interrupt {
-    ($controller:ident, unsafe fn $func_name:ident ($cs:ident $cstype:ty, $event:ident ButtonEvent ) $code:block) => {
-        macro_rules! handler {
+    ($controller:ident, unsafe fn $func_name:ident ($cs:ident $cstype:ty, event ButtonEvent ) $code:block) => {
+        macro_rules! _button_interrupt_handler {
             ($Interrupt:ident, $Handler:ident) => {
                 #[interrupt]
                 fn $Interrupt() {
                     disable_interrupts(|$cs| unsafe {
                         $controller.as_mut().map(|ctrlr| {
-                            if let Some($event) = ctrlr.$Handler() {
+                            if let Some(event) = ctrlr.$Handler() {
                                 $code
                             }
                         });
@@ -187,12 +187,12 @@ macro_rules! button_interrupt {
             };
         }
 
-        handler!(EIC_EXTINT_3, interrupt_extint3);
-        handler!(EIC_EXTINT_4, interrupt_extint4);
-        handler!(EIC_EXTINT_5, interrupt_extint5);
-        handler!(EIC_EXTINT_7, interrupt_extint7);
-        handler!(EIC_EXTINT_10, interrupt_extint10);
-        handler!(EIC_EXTINT_11, interrupt_extint11);
-        handler!(EIC_EXTINT_12, interrupt_extint12);
+        _button_interrupt_handler!(EIC_EXTINT_3, interrupt_extint3);
+        _button_interrupt_handler!(EIC_EXTINT_4, interrupt_extint4);
+        _button_interrupt_handler!(EIC_EXTINT_5, interrupt_extint5);
+        _button_interrupt_handler!(EIC_EXTINT_7, interrupt_extint7);
+        _button_interrupt_handler!(EIC_EXTINT_10, interrupt_extint10);
+        _button_interrupt_handler!(EIC_EXTINT_11, interrupt_extint11);
+        _button_interrupt_handler!(EIC_EXTINT_12, interrupt_extint12);
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod serial;
 mod sound;
 mod storage;
 
+pub mod buttons;
 pub use display::*;
 pub use pins::*;
 pub use sensors::*;

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -1,6 +1,7 @@
 use atsamd_hal::gpio::{self, *};
 use atsamd_hal::{define_pins, target_device};
 
+use super::buttons::ButtonPins;
 use super::display::Display;
 use super::sensors::{Accelerometer, LightSensor};
 use super::serial::{UART, USB};
@@ -29,7 +30,7 @@ define_pins!(
     pin switch_x = d8,
     pin switch_y = d9,
     pin switch_z = d10,
-    // pin switch_b = d12, // NOTE: `sd_det` is also mapped to `d12`
+    pin switch_b = d12,
     pin switch_u = d20,
 
     /// I2C
@@ -94,7 +95,7 @@ define_pins!(
     pin sd_sck = c17,
     pin sd_miso = c18,
     pin sd_cs = c19,
-    pin sd_det = d12,
+    pin sd_det = d21,
 
     /// WIFI/BLE
     pin rtl8720d_chip_pu = a18,
@@ -189,6 +190,8 @@ pub struct Sets {
 
     /// LED pin
     pub user_led: Pa15<Input<Floating>>,
+
+    pub buttons: ButtonPins,
 }
 
 impl Pins {
@@ -252,6 +255,17 @@ impl Pins {
 
         let user_led = self.user_led;
 
+        let buttons = ButtonPins {
+            button1: self.button1,
+            button2: self.button2,
+            button3: self.button3,
+            switch_x: self.switch_x,
+            switch_y: self.switch_y,
+            switch_z: self.switch_z,
+            switch_u: self.switch_u,
+            switch_b: self.switch_b,
+        };
+
         Sets {
             accelerometer,
             buzzer,
@@ -264,6 +278,7 @@ impl Pins {
             uart,
             usb,
             user_led,
+            buttons,
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,7 +1,7 @@
 #[rustfmt::skip]
 use atsamd_hal::gpio::{
     Floating, Input,
-    Pa8, Pa9, Pa10, Pa11, Pb10, Pb11, Pc16, Pc17, Pc18, Pc19, Pd12,
+    Pa8, Pa9, Pa10, Pa11, Pb10, Pb11, Pc16, Pc17, Pc18, Pc19, Pd21,
 };
 
 /// QSPI Flash pins (uses `SERCOM4`)
@@ -40,5 +40,5 @@ pub struct SDCard {
     pub miso: Pc18<Input<Floating>>,
 
     /// SD Card detect pin
-    pub det: Pd12<Input<Floating>>,
+    pub det: Pd21<Input<Floating>>,
 }


### PR DESCRIPTION
Depends on https://github.com/atsamd-rs/atsamd/pull/277

This PR implements a buttons controller, which is an interrupt-driven input type with hardware debouncing.

Unfortunately, the rightmost top button shares ExtInt10 with one axis on the joystick, so for now I removed that button. But everything else works well.

Ive also got an example that displays the buttons being pressed on the screen.